### PR TITLE
Update print() in test to work with Python3

### DIFF
--- a/tests/test_charges.py
+++ b/tests/test_charges.py
@@ -154,7 +154,7 @@ class OrdersEndpointTestCase(BaseEndpointTestCase):
     def test_18_spei_charge_done(self):
         self.client.api_key = '1tv5yJp3xnVZ7eK67m4h'
         charge = self.client.Charge.create(self.spei_charge_object)
-        print charge
+        print(charge)
         assert charge.id
 
     def test_19_spei_charge_authentication_fail(self):


### PR DESCRIPTION
The tests were failing at install time when using Python 3. This simple change fixes the test.

Las pruebas fue no funciona bien con Python 3. Este cambio corrige eso.

Gracias!
