### PR TITLE
Change: request refactor

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,9 @@ setup(
         ],
     packages=find_packages(),
     install_requires=[
-        'httplib2',
         'simplejson',
-        'nose'
+        'nose',
+        'requests'
     ],
     license='MIT License',
     keywords='conekta wrapper',


### PR DESCRIPTION
**Change: build_http_request  method refactor**
This change will  deprecate `httplib2` changing by `requests`, this stands to get compliance with tlsv1.2 because our current library uses tlsv1.0 (insecure version of transfer layer secutiry) by default, and is an immutable setup.
By using requests it uses your local tls version 1.2  as standard 
<hr>

[issue](https://github.com/conekta/issues/issues/1941)